### PR TITLE
Require Date before using it

### DIFF
--- a/validating-workflow.gemspec
+++ b/validating-workflow.gemspec
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require "date"
+
 Gem::Specification.new do |s|
   s.name = %q{validating-workflow}
   s.version = '0.7.9'


### PR DESCRIPTION
Without it, parsing this gemspec with Bundler 1.15.0 fails (Ruby 2.3.3):

```
[!] There was an error while loading `validating-workflow.gemspec`: uninitialized constant Date
Did you mean?  Data. Bundler cannot continue.

 #  from /Users/rglaser/.gem/ruby/2.3.3/bundler/gems/workflow-01f1b48fcd9d/validating-workflow.gemspec:9
 #  -------------------------------------------
 #    s.authors = ['Vladimir Dobriakov', 'Willem van Kerkhof']
 >    s.date = Date.today.to_s
 #    s.description = %q{Validating-Workflow is a finite-state-machine-inspired API for modeling and interacting
 #  -------------------------------------------
```